### PR TITLE
feat: Introduce custom error boundary transformation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,7 @@ use swc_core::{
 mod helpers;
 mod settings;
 
-pub use settings::{Config, Context, Environment};
+pub use settings::{Config, Context, CustomBoundarySetting, Environment}; // Added CustomBoundarySetting
 
 const SUSPENSE_TRACKER_PACKAGE: &str = "react-swc-suspense-tracker/context";
 const SUSPENSE_TRACKER_IMPORT_NAME: &str = "SuspenseTrackerSWC";
@@ -30,6 +30,10 @@ struct TransformVisitor {
     react_suspense_contexts: HashSet<SyntaxContext>,
     /// Position to insert the SuspenseTracker import (after React import)
     react_import_position: Option<usize>,
+    /// Set of SyntaxContext IDs for ErrorBoundary identifiers from custom config
+    error_boundary_contexts: HashSet<SyntaxContext>,
+    /// Configuration for the matched custom error boundary
+    custom_boundary_config: Option<CustomBoundarySetting>,
 }
 
 impl TransformVisitor {
@@ -41,13 +45,16 @@ impl TransformVisitor {
             suspense_tracker_imported: false,
             react_suspense_contexts: HashSet::new(),
             react_import_position: None,
+            error_boundary_contexts: HashSet::new(),
+            custom_boundary_config: None,
         }
     }
 
-    /// Generates a unique ID for a Suspense element based on file and line
-    fn generate_suspense_id(&self, span_lo: u32) -> String {
+    /// Generates a unique ID for a boundary element based on file and line
+    fn generate_boundary_id(&self, name: &str, span_lo: u32) -> String {
         let line = helpers::extract_line_number(span_lo);
-        helpers::generate_boundary_id(&self.context.filename, line)
+        // Using the original component name in the ID for better traceability
+        helpers::generate_boundary_id(&format!("{}-{}", &self.context.filename, name), line)
     }
 
     /// Creates the SuspenseTracker import if needed
@@ -135,7 +142,9 @@ impl VisitMut for TransformVisitor {
             return;
         }
 
-        // First pass: collect React Suspense imports and find React import position
+        // First pass: Process imports
+        // - Collect React Suspense imports and find React import position
+        // - Process custom boundary imports
         for (index, module_item) in module_items.iter_mut().enumerate() {
             if let ModuleItem::ModuleDecl(ModuleDecl::Import(import_decl)) = module_item {
                 let Str { value, .. } = *import_decl.src.clone();
@@ -143,11 +152,15 @@ impl VisitMut for TransformVisitor {
                     self.react_import_position = Some(index);
                     self.process_react_import(import_decl);
                 }
+                // Process for custom boundaries even if not "react" import
+                self.process_custom_boundary_imports(import_decl);
             }
         }
 
-        // Second pass: transform JSX elements (only if we found React Suspense imports)
-        if !self.react_suspense_contexts.is_empty() {
+        // Second pass: transform JSX elements
+        // (Suspense transformations depend on react_suspense_contexts)
+        // (Error Boundary transformations depend on error_boundary_contexts)
+        if !self.react_suspense_contexts.is_empty() || !self.error_boundary_contexts.is_empty() {
             module_items.visit_mut_children_with(self);
         }
 
@@ -168,13 +181,64 @@ impl VisitMut for TransformVisitor {
     }
 
     fn visit_mut_jsx_element(&mut self, jsx_element: &mut JSXElement) {
-        // Only transform if this is a React Suspense element
-        if self.is_react_suspense(jsx_element) {
+        let mut transformed_to_custom_boundary = false;
+
+        // Check for Custom Error Boundary transformation first
+        if let Some(custom_boundary_config) = &self.custom_boundary_config {
+            if let JSXElementName::Ident(ident) = &jsx_element.opening.name {
+                if self.error_boundary_contexts.contains(&ident.ctxt) {
+                    // This JSX element matches a configured custom error boundary
+                    transformed_to_custom_boundary = true;
+
+                    // Change the element name to "CustomBoundary" (unhygienic)
+                    let custom_boundary_ident = Ident::new(
+                        "CustomBoundary".into(),
+                        DUMMY_SP.with_ctxt(SyntaxContext::empty()),
+                    );
+                    jsx_element.opening.name = JSXElementName::Ident(custom_boundary_ident.clone());
+                    if let Some(ref mut closing) = jsx_element.closing {
+                        closing.name = JSXElementName::Ident(custom_boundary_ident);
+                    }
+
+                    // Add `component` attribute with the original ErrorBoundary's identifier
+                    let component_attr = JSXAttrOrSpread::JSXAttr(JSXAttr {
+                        span: DUMMY_SP,
+                        name: JSXAttrName::Ident(Ident::new("component".into(), DUMMY_SP)),
+                        value: Some(JSXAttrValue::JSXExprContainer(JSXExprContainer {
+                            span: DUMMY_SP,
+                            expr: JSXExpr::Expr(Box::new(Expr::Ident(ident.clone()))),
+                        })),
+                    });
+                    jsx_element.opening.attrs.push(component_attr);
+
+                    // Add `id` attribute
+                    let id_value =
+                        self.generate_boundary_id(&ident.sym, jsx_element.span.lo.0);
+                    let id_attr = JSXAttrOrSpread::JSXAttr(JSXAttr {
+                        span: DUMMY_SP,
+                        name: JSXAttrName::Ident(Ident::new("id".into(), DUMMY_SP)),
+                        value: Some(JSXAttrValue::Lit(Lit::Str(Str {
+                            span: DUMMY_SP,
+                            value: id_value.into(),
+                            raw: None,
+                        }))),
+                    });
+                    jsx_element.opening.attrs.push(id_attr);
+
+                    // Potentially, we might need to mark that a "CustomBoundary" import is needed,
+                    // similar to has_suspense_elements, if it's not globally available.
+                    // For now, this is outside the scope of this specific change.
+                }
+            }
+        }
+
+        // If not transformed to CustomBoundary, check for React Suspense transformation
+        if !transformed_to_custom_boundary && self.is_react_suspense(jsx_element) {
             self.has_suspense_elements = true;
 
             // Change the element name to SuspenseTracker
             jsx_element.opening.name = JSXElementName::Ident(Ident {
-                ctxt: Default::default(),
+                ctxt: SyntaxContext::empty(), // Make it unhygienic to match global/module import
                 span: DUMMY_SP,
                 sym: SUSPENSE_TRACKER_IMPORT_NAME.into(),
                 optional: false,
@@ -183,7 +247,7 @@ impl VisitMut for TransformVisitor {
             // Also update closing tag if it exists
             if let Some(ref mut closing) = jsx_element.closing {
                 closing.name = JSXElementName::Ident(Ident {
-                    ctxt: Default::default(),
+                    ctxt: SyntaxContext::empty(), // Make it unhygienic
                     span: DUMMY_SP,
                     sym: SUSPENSE_TRACKER_IMPORT_NAME.into(),
                     optional: false,
@@ -191,13 +255,13 @@ impl VisitMut for TransformVisitor {
             }
 
             // Add the id prop
-            let id_value = self.generate_suspense_id(jsx_element.span.lo.0);
+            let id_value = self.generate_boundary_id("Suspense", jsx_element.span.lo.0);
 
             let id_attr = JSXAttrOrSpread::JSXAttr(JSXAttr {
                 span: DUMMY_SP,
                 name: JSXAttrName::Ident(IdentName {
                     span: DUMMY_SP,
-                    sym: "id".into(),
+                    sym: "id".into(), // Corrected: IdentName expects Ident
                 }),
                 value: Some(JSXAttrValue::Lit(Lit::Str(Str {
                     span: DUMMY_SP,
@@ -210,6 +274,71 @@ impl VisitMut for TransformVisitor {
         }
 
         jsx_element.visit_mut_children_with(self);
+    }
+}
+
+impl TransformVisitor {
+    // ... (other methods like new, generate_boundary_id, create_suspense_tracker_import, process_react_import, is_react_suspense)
+
+    /// Processes custom boundary imports: collects their identifier contexts
+    fn process_custom_boundary_imports(&mut self, import_decl: &mut ImportDecl) {
+        if let Some(custom_boundaries_map) = &self.config.custom_boundaries {
+            let import_source = &import_decl.src.value;
+
+            for (_key, boundary_setting) in custom_boundaries_map.iter() {
+                if &boundary_setting.from == import_source {
+                    // This import declaration matches a configured custom boundary source
+                    for specifier in &import_decl.specifiers {
+                        match specifier {
+                            ImportSpecifier::Named(named_spec) => {
+                                // Check if the imported component name (either original or alias)
+                                // matches the configured component name.
+                                let imported_name = named_spec
+                                    .imported
+                                    .as_ref()
+                                    .map(|module_export_name| match module_export_name {
+                                        ModuleExportName::Ident(ident) => &ident.sym,
+                                        ModuleExportName::Str(s) => &s.value,
+                                    })
+                                    .unwrap_or(&named_spec.local.sym);
+
+                                if imported_name == &boundary_setting.component {
+                                    self.error_boundary_contexts
+                                        .insert(named_spec.local.span.ctxt);
+                                    // Store the first matching configuration.
+                                    // If multiple boundaries could be matched by one import,
+                                    // this picks the one iterated first in the HashMap.
+                                    // A more sophisticated system might be needed for conflicts.
+                                    if self.custom_boundary_config.is_none() {
+                                        self.custom_boundary_config = Some(boundary_setting.clone());
+                                    }
+                                    // Note: We don't remove the import specifier here as the
+                                    // user's code still needs the original ErrorBoundary component
+                                    // to be passed as a prop to CustomBoundary.
+                                }
+                            }
+                            ImportSpecifier::Default(default_spec) => {
+                                // If the configured component name matches the default import's local name
+                                if default_spec.local.sym == boundary_setting.component {
+                                     self.error_boundary_contexts
+                                        .insert(default_spec.local.span.ctxt);
+                                    if self.custom_boundary_config.is_none() {
+                                        self.custom_boundary_config = Some(boundary_setting.clone());
+                                    }
+                                }
+                            }
+                            ImportSpecifier::Namespace(_) => {
+                                // Namespace imports are trickier. For now, we might ignore them
+                                // or require specific naming conventions if they are to be supported.
+                                // e.g., if boundary_setting.component is "MyNamespace.ErrorBoundary"
+                                // This would require parsing the component string.
+                                // For simplicity, let's assume named/default imports for now.
+                            }
+                        }
+                    }
+                }
+            }
+        }
     }
 }
 
@@ -261,6 +390,7 @@ pub fn process_transform(program: Program, metadata: TransformPluginProgramMetad
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::collections::HashMap; // For custom_boundaries in test config
     use swc_core::ecma::{
         parser::{Syntax, TsSyntax},
         transforms::testing::test,
@@ -335,16 +465,25 @@ function App() {
   );
 }"#;
 
-    fn transform_visitor(environment: Environment) -> VisitMutPass<TransformVisitor> {
+    fn transform_visitor_with_config(
+        environment: Environment,
+        custom_boundaries: Option<HashMap<String, CustomBoundarySetting>>,
+    ) -> VisitMutPass<TransformVisitor> {
         visit_mut_pass(TransformVisitor::new(
             Config {
                 enabled: Some(true),
+                custom_boundaries,
             },
             Context {
                 env_name: environment,
                 filename: "my/file.tsx".into(),
             },
         ))
+    }
+
+    // Keep old helper for existing suspense tests for simplicity
+    fn transform_visitor(environment: Environment) -> VisitMutPass<TransformVisitor> {
+        transform_visitor_with_config(environment, None)
     }
 
     fn tsx_syntax() -> Syntax {
@@ -419,5 +558,214 @@ function App() {
         |_| transform_visitor(Environment::Test),
         test_no_transform,
         BASIC_SUSPENSE
+    );
+
+    // --- Custom Error Boundary Tests ---
+
+    const CUSTOM_ERROR_BOUNDARY_BASIC_IMPORT: &str =
+        r#"import { MyErrorBoundary } from "my-error-lib";
+function App() {
+  return (
+    <MyErrorBoundary>
+      <MyComponent />
+    </MyErrorBoundary>
+  );
+}"#;
+
+    const CUSTOM_ERROR_BOUNDARY_ALIASED_IMPORT: &str =
+        r#"import { MyErrorBoundary as CustomEB } from "my-error-lib";
+function App() {
+  return (
+    <CustomEB>
+      <MyComponent />
+    </CustomEB>
+  );
+}"#;
+
+    const CUSTOM_ERROR_BOUNDARY_DEFAULT_IMPORT: &str =
+        r#"import DefaultErrorBoundary from "my-error-lib";
+function App() {
+  return (
+    <DefaultErrorBoundary>
+      <MyComponent />
+    </DefaultErrorBoundary>
+  );
+}"#;
+
+    const CUSTOM_ERROR_BOUNDARY_MIXED_SUSPENSE: &str =
+        r#"import { Suspense } from "react";
+import { MyErrorBoundary } from "my-error-lib";
+function App() {
+  return (
+    <div>
+      <Suspense fallback={<Loading />}>
+        <Component1 />
+      </Suspense>
+      <MyErrorBoundary>
+        <Component2 />
+      </MyErrorBoundary>
+    </div>
+  );
+}"#;
+
+    fn custom_boundary_config(
+        key: &str,
+        component_name: &str,
+        from_module: &str,
+    ) -> HashMap<String, CustomBoundarySetting> {
+        let mut boundaries = HashMap::new();
+        boundaries.insert(
+            key.to_string(),
+            CustomBoundarySetting {
+                component: component_name.to_string(),
+                from: from_module.to_string(),
+            },
+        );
+        boundaries
+    }
+
+    test!(
+        module,
+        tsx_syntax(),
+        |_| transform_visitor_with_config(
+            Environment::Development,
+            Some(custom_boundary_config(
+                "errorBoundary",
+                "MyErrorBoundary",
+                "my-error-lib"
+            ))
+        ),
+        custom_error_boundary_transform_basic,
+        CUSTOM_ERROR_BOUNDARY_BASIC_IMPORT,
+        r#"import { MyErrorBoundary } from "my-error-lib";
+function App() {
+    return (
+        <CustomBoundary component={MyErrorBoundary} id="my/file.tsx-MyErrorBoundary-L4">
+            <MyComponent />
+        </CustomBoundary>
+    );
+}"#
+    );
+
+    test!(
+        module,
+        tsx_syntax(),
+        |_| transform_visitor_with_config(
+            Environment::Development,
+            Some(custom_boundary_config(
+                "errorBoundary",
+                "MyErrorBoundary",
+                "my-error-lib"
+            ))
+        ),
+        custom_error_boundary_transform_aliased,
+        CUSTOM_ERROR_BOUNDARY_ALIASED_IMPORT,
+        r#"import { MyErrorBoundary as CustomEB } from "my-error-lib";
+function App() {
+    return (
+        <CustomBoundary component={CustomEB} id="my/file.tsx-CustomEB-L4">
+            <MyComponent />
+        </CustomBoundary>
+    );
+}"#
+    );
+
+    test!(
+        module,
+        tsx_syntax(),
+        |_| transform_visitor_with_config(
+            Environment::Development,
+            Some(custom_boundary_config(
+                "errorBoundary",
+                "DefaultErrorBoundary",
+                "my-error-lib"
+            ))
+        ),
+        custom_error_boundary_transform_default,
+        CUSTOM_ERROR_BOUNDARY_DEFAULT_IMPORT,
+        r#"import DefaultErrorBoundary from "my-error-lib";
+function App() {
+    return (
+        <CustomBoundary component={DefaultErrorBoundary} id="my/file.tsx-DefaultErrorBoundary-L4">
+            <MyComponent />
+        </CustomBoundary>
+    );
+}"#
+    );
+
+    test!(
+        module,
+        tsx_syntax(),
+        |_| transform_visitor_with_config(Environment::Development, None),
+        custom_error_boundary_no_config_no_transform,
+        CUSTOM_ERROR_BOUNDARY_BASIC_IMPORT
+    );
+
+    test!(
+        module,
+        tsx_syntax(),
+        |_| transform_visitor_with_config(
+            Environment::Development,
+            Some(custom_boundary_config(
+                "errorBoundary",
+                "OtherBoundary",
+                "my-error-lib"
+            ))
+        ),
+        custom_error_boundary_wrong_component_no_transform,
+        CUSTOM_ERROR_BOUNDARY_BASIC_IMPORT
+    );
+
+    test!(
+        module,
+        tsx_syntax(),
+        |_| transform_visitor_with_config(
+            Environment::Development,
+            Some(custom_boundary_config(
+                "errorBoundary",
+                "MyErrorBoundary",
+                "other-lib"
+            ))
+        ),
+        custom_error_boundary_wrong_module_no_transform,
+        CUSTOM_ERROR_BOUNDARY_BASIC_IMPORT
+    );
+
+    test!(
+        module,
+        tsx_syntax(),
+        |_| transform_visitor_with_config(
+            Environment::Development,
+            Some(custom_boundary_config(
+                "errorBoundary",
+                "MyErrorBoundary",
+                "my-error-lib"
+            ))
+        ),
+        custom_error_boundary_mixed_with_suspense,
+        CUSTOM_ERROR_BOUNDARY_MIXED_SUSPENSE,
+        r#"import { SuspenseTrackerSWC } from "react-swc-suspense-tracker/context";
+import { MyErrorBoundary } from "my-error-lib";
+function App() {
+    return (
+        <div>
+            <SuspenseTrackerSWC id="my/file.tsx-Suspense-L5" fallback={<Loading />}>
+                <Component1 />
+            </SuspenseTrackerSWC>
+            <CustomBoundary component={MyErrorBoundary} id="my/file.tsx-MyErrorBoundary-L8">
+                <Component2 />
+            </CustomBoundary>
+        </div>
+    );
+}"#
+    );
+
+    // Test that if custom_boundaries is Some but empty, it doesn't break
+    test!(
+        module,
+        tsx_syntax(),
+        |_| transform_visitor_with_config(Environment::Development, Some(HashMap::new())),
+        custom_error_boundary_empty_config_no_transform,
+        CUSTOM_ERROR_BOUNDARY_BASIC_IMPORT
     );
 }

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -1,4 +1,14 @@
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap; // Added for HashMap
+
+/// Settings for a custom boundary component.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[serde(deny_unknown_fields)]
+pub struct CustomBoundarySetting {
+    pub component: String,
+    pub from: String,
+}
 
 /// Static plugin configuration.
 #[derive(Debug, Serialize, Deserialize)]
@@ -8,6 +18,9 @@ pub struct Config {
     /// Whether the plugin is enabled
     #[serde(default = "default_enabled")]
     pub enabled: Option<bool>,
+    /// Configuration for custom boundaries
+    #[serde(default)] // Add default for Option<HashMap<...>>
+    pub custom_boundaries: Option<HashMap<String, CustomBoundarySetting>>,
 }
 
 /// Default value for the enabled field (defaults to Some(true) if not specified).


### PR DESCRIPTION
This change allows you to configure a custom error boundary component that will be transformed by the SWC plugin.

The transformation replaces your user-defined error boundary component (e.g., `<MyErrorBoundary>`) with a `<CustomBoundary>` component. The original component is passed as a `component` prop to `<CustomBoundary>`, and an `id` prop is added for traceability, similar to how Suspense boundaries are handled.

Configuration is done via the plugin settings:
```json
{
  "customBoundaries": {
    "errorBoundary": {
      "component": "MyErrorBoundary",
      "from": "my-error-boundary-library"
    }
  }
}
```

This enables more flexible error handling strategies by allowing different error boundary components to be used and tracked by the plugin.

The following have been updated:
- `src/settings.rs`: Added `CustomBoundarySetting` struct and `custom_boundaries` option to `Config`.
- `src/lib.rs`:
    - Updated `TransformVisitor` to include logic for identifying and transforming configured custom error boundaries.
    - Added `process_custom_boundary_imports` to handle the imports of these boundaries.
    - Modified `visit_mut_jsx_element` to perform the transformation.
    - Added extensive tests to cover various import types (named, aliased, default), configurations, and interactions with existing Suspense transformations.